### PR TITLE
Update docker-compose.yml and remove rss-bridge container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.3"
-
 services:
 
   searx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   searx:
     container_name: searx
-    image: searx/searx:0.18.0-341-ae0b621e
+    image: searx/searx:1.1.0-69-75b859d2
     hostname: searx
     restart: always
     networks:
@@ -26,21 +26,6 @@ services:
       - SETGID
       - SETUID
       - DAC_OVERRIDE
-
-  rss-bridge:
-    container_name: rss-bridge
-    image: rssbridge/rss-bridge:latest
-    hostname: rss-bridge
-    restart: always
-    networks:
-      default:
-        ipv4_address: 10.10.10.7
-    volumes:
-      - ./Rss-bridge/whitelist.txt:/app/whitelist.txt
-    environment:
-      - TZ=${TZ}
-      - HTTP_PROXY=${HTTP_PROXY}
-      - HTTPS_PROXY=${HTTPS_PROXY}
 
   db_watcher:
     container_name: db_watcher
@@ -66,7 +51,6 @@ services:
     depends_on:
       - db_watcher
       - searx
-      - rss-bridge
     restart: always
     networks:
       default:


### PR DESCRIPTION
Updated the docker-compose.yml file to remove the '3.3' version and apply the new standard. Removed the rss-bridge container and all associated references from the project as it is no longer needed.