### PR TITLE
Update docker-compose.yml and remove rss-bridge container

### DIFF
--- a/Rss-bridge/whitelist.txt
+++ b/Rss-bridge/whitelist.txt
@@ -1,1 +1,0 @@
-TwitterBridge


### PR DESCRIPTION
Updated the docker-compose.yml file to remove the '3.3' version and apply the new standard. Removed the rss-bridge container and all associated references from the project as it is no longer needed.